### PR TITLE
adjust cn regex to possible whitespaces

### DIFF
--- a/easyroam.sh
+++ b/easyroam.sh
@@ -103,7 +103,7 @@ if [[ $? -ne 0 ]]; then
 fi
 echo "Done"
 
-cn=$(openssl x509 -noout -subject -in easyroam_client_cert.pem | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
+cn=$(openssl x509 -noout -subject -in easyroam_client_cert.pem | sed -n 's/^.*CN *= *\([^,]*\).*$/\1/p')
 
 echo -n "Build private key... "
 openssl pkcs12 "$LEGACY" -in "$p12name" -nodes -nocerts -passin pass: | openssl rsa -aes256 -passout pass:"$pkpw" -out easyroam_client_key.pem -legacy 2>/dev/null

--- a/easyroam_nm.sh
+++ b/easyroam_nm.sh
@@ -120,7 +120,7 @@ if [[ $? -ne 0 ]]; then
 fi
 echo "Done"
 
-cn=$(openssl x509 -noout -subject -in easyroam_client_cert.pem | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
+cn=$(openssl x509 -noout -subject -in easyroam_client_cert.pem | sed -n 's/^.*CN *= *\([^,]*\).*$/\1/p')
 
 echo -n "Build private key... "
 openssl pkcs12 "$LEGACY" -in "$p12name" -nodes -nocerts -passin pass: | openssl rsa -aes256 -passout pass:"$PKPW" -out easyroam_client_key.pem -legacy 2>/dev/null


### PR DESCRIPTION
@jahtz 
In my case, the openssl contained whitespaces like this:
```
subject=X = XX, ST = City, L = City, O = Test Organization, OU = test unit, CN = 123456789@test.test.uri
```
Therefore, the script could not extract the correct CN. The proposed changes will fix this issue by ignoring any number of whitespaces in the Regex.